### PR TITLE
build(deps-dev): bump the dev-deps group across 1 directory with 7 up…

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "bootstrap": "^5.3.3"
   },
   "devDependencies": {
-    "@babel/core": "^7.25.2",
-    "@babel/plugin-transform-class-properties": "^7.25.4",
-    "@babel/preset-env": "^7.25.4",
+    "@babel/core": "^7.25.8",
+    "@babel/plugin-transform-class-properties": "^7.25.7",
+    "@babel/preset-env": "^7.25.8",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
     "@rollup/plugin-babel": "^6.0.4",
-    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-terser": "^0.4.4",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^6.0.3",
@@ -43,9 +43,9 @@
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "husky": "^9.1.6",
     "purgecss": "^6.0.0",
-    "rollup": "^4.21.3",
-    "semantic-release": "^24.1.1",
-    "stylelint": "^16.9.0",
+    "rollup": "^4.24.0",
+    "semantic-release": "^24.1.2",
+    "stylelint": "^16.10.0",
     "stylelint-config-standard-scss": "^13.1.0"
   },
   "prettier": {


### PR DESCRIPTION
…dates

Updates the requirements on [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core), [@babel/plugin-transform-class-properties](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-class-properties), [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env), [@rollup/plugin-node-resolve](https://github.com/rollup/plugins/tree/HEAD/packages/node-resolve), [rollup](https://github.com/rollup/rollup), [semantic-release](https://github.com/semantic-release/semantic-release) and [stylelint](https://github.com/stylelint/stylelint) to permit the latest version.

Updates `@babel/core` to 7.25.8
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.25.8/packages/babel-core)

Updates `@babel/plugin-transform-class-properties` to 7.25.7
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.25.7/packages/babel-plugin-transform-class-properties)

Updates `@babel/preset-env` to 7.25.8
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.25.8/packages/babel-preset-env)

Updates `@rollup/plugin-node-resolve` to 15.3.0
- [Changelog](https://github.com/rollup/plugins/blob/master/packages/node-resolve/CHANGELOG.md)
- [Commits](https://github.com/rollup/plugins/commits/node-resolve-v15.3.0/packages/node-resolve)

Updates `rollup` to 4.24.0
- [Release notes](https://github.com/rollup/rollup/releases)
- [Changelog](https://github.com/rollup/rollup/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rollup/rollup/compare/v4.21.3...v4.24.0)

Updates `semantic-release` to 24.1.2
- [Release notes](https://github.com/semantic-release/semantic-release/releases)
- [Commits](https://github.com/semantic-release/semantic-release/compare/v24.1.1...v24.1.2)

Updates `stylelint` to 16.10.0
- [Release notes](https://github.com/stylelint/stylelint/releases)
- [Changelog](https://github.com/stylelint/stylelint/blob/main/CHANGELOG.md)
- [Commits](https://github.com/stylelint/stylelint/compare/16.9.0...16.10.0)

---
updated-dependencies:
- dependency-name: "@babel/core" dependency-type: direct:development dependency-group: dev-deps
- dependency-name: "@babel/plugin-transform-class-properties" dependency-type: direct:development dependency-group: dev-deps
- dependency-name: "@babel/preset-env" dependency-type: direct:development dependency-group: dev-deps
- dependency-name: "@rollup/plugin-node-resolve" dependency-type: direct:development dependency-group: dev-deps
- dependency-name: rollup dependency-type: direct:development dependency-group: dev-deps
- dependency-name: semantic-release dependency-type: direct:development dependency-group: dev-deps
- dependency-name: stylelint dependency-type: direct:development dependency-group: dev-deps ...

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

## Additional context
<!-- e.g. Fixes #(issue) -->
